### PR TITLE
Enhance music link handling in notes by adding a check for embedded m…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,27 @@ jobs:
           fi
           echo "Build verification successful"
 
+      - name: Notes embed – check musicLinks in built HTML
+        run: |
+          echo "--- Notes embed: __NOTE_MUSIC_LINKS__ in built note pages ---"
+          empty=0
+          filled=0
+          for f in dist/notes/*/index.html; do
+            [ -f "$f" ] || continue
+            if grep -q '__NOTE_MUSIC_LINKS__ = {}' "$f" 2>/dev/null; then
+              echo "[empty] $f – musicLinks は空です（タブはクライアント fetch に依存。CORS で失敗する可能性あり）"
+              empty=$((empty + 1))
+            elif grep -q '__NOTE_MUSIC_LINKS__' "$f" 2>/dev/null; then
+              echo "[filled] $f – musicLinks が埋め込まれています"
+              filled=$((filled + 1))
+            fi
+          done
+          if [ "$empty" -eq 0 ] && [ "$filled" -eq 0 ]; then
+            echo "（notes のビルド成果がありません）"
+          else
+            echo "--- 集計: empty=$empty, filled=$filled ---"
+          fi
+
       # FTP はサーバー上の .ftp-deploy-sync-state.json で差分だけアップロード（新記事だけ反映）
       - name: FTP Deploy to Lolipop
         uses: SamKirkland/FTP-Deploy-Action@v4.3.6

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -69,7 +69,7 @@ collections:
         name: "body"
         widget: "markdown"
         required: true
-        hint: "画像は「メディアを追加」で Cloudinary から選択。音声/動画（mp3/mp4等）は画像ボタンではなく、Cloudinaryでアップロード後に配信URLを本文へ貼り付けてください"
+        hint: "画像は「メディアを追加」で Cloudinary から選択。音声/動画（mp3/mp4等）は画像ボタンではなく、Cloudinaryでアップロード後に配信URLを本文へ貼り付けてください。改行を続けて空白を作れない場合は、HTMLで <div class=\"content-spacer\"></div> を挿入してください。"
 
   # ライブ
   - name: "live"

--- a/scripts/vite-notes-mdx-autolink.mjs
+++ b/scripts/vite-notes-mdx-autolink.mjs
@@ -1,38 +1,44 @@
 /**
- * Vite plugin: notes の .mdx 内で `<https://...>` 形式のURLを
- * Markdown リンク `[url](url)` に変換する。
- * Decap CMS などが角括弧URLで保存しても MDX の JSX 解釈でエラーにならないようにする。
+ * Vite plugin: notes の .mdx 用の前処理
+ * - `<https://...>` 形式のURLを Markdown リンク `[url](url)` に変換
+ * - 本文中の 3 回以上の連続改行をスペーサー用 HTML に置換（表示で空白を保持）
  */
-import fs from "node:fs";
 import path from "node:path";
 
 const NOTES_MDX_RE = /content[/\\]notes[/\\].*\.mdx$/i;
+
+const SPACER_HTML = "\n\n<div class=\"content-spacer\" aria-hidden=\"true\"></div>\n\n";
 
 /** 角括弧で囲まれた http(s) URL を [url](url) に置換 */
 function transformAngleBracketUrls(source) {
   return source.replace(/<(https?:\/\/[^>]+)>/g, (_, url) => `[${url}](${url})`);
 }
 
+/** 本文（frontmatter の後）の 3 回以上の連続改行をスペーサーに置換 */
+function preserveBlankLinesInBody(source) {
+  const idx = source.indexOf("\n---\n");
+  const bodyStart = idx !== -1 ? idx + 5 : 0;
+  const head = source.slice(0, bodyStart);
+  const body = source.slice(bodyStart);
+  const newBody = body.replace(/\n{3,}/g, SPACER_HTML);
+  return head + newBody;
+}
+
 function isNotesMdx(id) {
   return NOTES_MDX_RE.test(path.normalize(id));
+}
+
+function transformNotesMdx(code) {
+  return preserveBlankLinesInBody(transformAngleBracketUrls(code));
 }
 
 export default function viteNotesMdxAutolink() {
   return {
     name: "vite-notes-mdx-autolink",
     enforce: "pre",
-    load(id) {
-      if (!isNotesMdx(id)) return null;
-      try {
-        const raw = fs.readFileSync(id, "utf-8");
-        return { code: transformAngleBracketUrls(raw) };
-      } catch {
-        return null;
-      }
-    },
     transform(code, id) {
       if (!isNotesMdx(id)) return null;
-      return { code: transformAngleBracketUrls(code), map: null };
+      return { code: transformNotesMdx(code), map: null };
     },
   };
 }

--- a/src/layouts/NotePost.astro
+++ b/src/layouts/NotePost.astro
@@ -37,8 +37,7 @@ const timeStr = date.toLocaleTimeString("ja-JP", {
 });
 const dateTimeDisplay = `${dateStr} ${timeStr}`;
 
-/** song.link 取得失敗時に通知する先（未設定なら送信しない） */
-const musicLinkReportUrl = (import.meta.env.PUBLIC_NOTE_MUSIC_LINK_REPORT_URL as string) ?? "";
+
 ---
 
 <Base title={title}>
@@ -103,21 +102,8 @@ const musicLinkReportUrl = (import.meta.env.PUBLIC_NOTE_MUSIC_LINK_REPORT_URL as
 
 <script is:inline set:html={`window.__NOTE_MUSIC_LINKS__ = ${JSON.stringify(musicLinks).replace(/</g, "\\u003c")};`} />
 
-<script define:vars={{ ODESSLI_API: "https://api.song.link/v1-alpha.1/links", MUSIC_LINK_REPORT_URL: musicLinkReportUrl }}>
-  function reportMusicLinkFailure(musicUrl, reason) {
-    if (!MUSIC_LINK_REPORT_URL) return;
-    try {
-      const body = JSON.stringify({
-        type: "note_music_link_failed",
-        musicUrl,
-        reason,
-        page: typeof location !== "undefined" ? location.href : "",
-        at: new Date().toISOString(),
-      });
-      fetch(MUSIC_LINK_REPORT_URL, { method: "POST", body, headers: { "Content-Type": "application/json" }, keepalive: true }).catch(() => {});
-    } catch (e) {}
-  }
-
+<script>
+  // タブ用データはビルド時にのみ取得（ブラウザから api.song.link は CORS で取得不可のためクライアント fetch は行わない）
   function pageUrlToEmbedUrl(pageUrl, service) {
     if (!pageUrl || typeof pageUrl !== "string") return null;
     const u = pageUrl.trim();
@@ -171,23 +157,8 @@ const musicLinkReportUrl = (import.meta.env.PUBLIC_NOTE_MUSIC_LINK_REPORT_URL as
         Array.from(container.querySelectorAll(".note-embed-music-frame")).map((f) => f.dataset?.service).filter(Boolean)
       );
 
-      let linksByPlatform = {};
       const preloaded = typeof window !== "undefined" && window.__NOTE_MUSIC_LINKS__ && window.__NOTE_MUSIC_LINKS__[url];
-      if (preloaded && preloaded.linksByPlatform) {
-        linksByPlatform = preloaded.linksByPlatform;
-      } else {
-        try {
-          const res = await fetch(`${ODESSLI_API}?url=${encodeURIComponent(url)}`);
-          if (res.ok) {
-            const data = await res.json();
-            linksByPlatform = data?.linksByPlatform || {};
-          } else {
-            reportMusicLinkFailure(url, "http " + res.status);
-          }
-        } catch (err) {
-          reportMusicLinkFailure(url, err && err.message ? err.message : "network error");
-        }
-      }
+      const linksByPlatform = (preloaded && preloaded.linksByPlatform) ? preloaded.linksByPlatform : {};
         const framesWrap = container.querySelector(".note-embed-music-frames");
         const tablist = container.querySelector(".note-embed-music-tablist");
         if (!framesWrap || !tablist) {
@@ -374,6 +345,13 @@ const musicLinkReportUrl = (import.meta.env.PUBLIC_NOTE_MUSIC_LINK_REPORT_URL as
   .post-content :global(p) {
     margin: 0 0 1em;
     white-space: pre-wrap;
+  }
+
+  /* 複数改行で入れた空白用スペーサー（remark-preserve-blank-lines が挿入） */
+  .post-content :global(.content-spacer) {
+    display: block;
+    min-height: 1em;
+    margin: 0;
   }
 
   .post-content :global(h1),

--- a/src/pages/notes/[slug].astro
+++ b/src/pages/notes/[slug].astro
@@ -5,8 +5,48 @@ import NotePost from '../../layouts/NotePost.astro';
 import NoteEmbedLink from '../../components/NoteEmbedLink.astro';
 import NoteImage from '../../components/NoteImage.astro';
 
-// song.link はビルド時ではなくクライアントで取得（本番ビルド環境で API が叩けない場合があるため）
-const musicLinks: Record<string, { linksByPlatform?: Record<string, { url?: string }> }> = {};
+const SONG_LINK_API = "https://api.song.link/v1-alpha.1/links";
+
+/** 本文から Spotify / Apple Music の URL を抽出（重複除く・順序保持） */
+function extractMusicUrls(body: string): string[] {
+  const re = /https?:\/\/(?:open\.)?spotify\.com\/[^\s\)\]"']+|https?:\/\/(?:music|geo\.music)\.apple\.com\/[^\s\)\]"']+/gi;
+  const seen = new Set<string>();
+  const urls: string[] = [];
+  for (const m of body.matchAll(re)) {
+    const u = m[0];
+    if (!seen.has(u)) {
+      seen.add(u);
+      urls.push(u);
+    }
+  }
+  return urls;
+}
+
+/** ビルド時に song.link API で他サービス URL を取得（CORS 回避）。結果をログ出力。 */
+async function fetchMusicLinksForUrls(
+  urls: string[],
+  slug: string
+): Promise<Record<string, { linksByPlatform?: Record<string, { url?: string }> }>> {
+  const out: Record<string, { linksByPlatform?: Record<string, { url?: string }> }> = {};
+  if (urls.length === 0) return out;
+  console.log(`[notes/${slug}] 音楽 URL を ${urls.length} 件検出。song.link を呼び出します。`);
+  for (const url of urls) {
+    try {
+      const res = await fetch(`${SONG_LINK_API}?url=${encodeURIComponent(url)}`);
+      if (!res.ok) {
+        console.warn(`[notes/${slug}] song.link 失敗: ${url.slice(0, 50)}... → HTTP ${res.status}`);
+        continue;
+      }
+      const data = (await res.json()) as { linksByPlatform?: Record<string, { url?: string }> };
+      out[url] = { linksByPlatform: data?.linksByPlatform ?? {} };
+      const platforms = Object.keys(out[url].linksByPlatform ?? {}).filter((k) => out[url].linksByPlatform![k]?.url);
+      console.log(`[notes/${slug}] song.link 成功: ${url.slice(0, 50)}... → ${platforms.length} プラットフォーム`);
+    } catch (err) {
+      console.warn(`[notes/${slug}] song.link 例外:`, err instanceof Error ? err.message : String(err));
+    }
+  }
+  return out;
+}
 
 // 本番は公開記事のみ、stg（base /stg/）では非公開も含めて全件ビルド
 export const getStaticPaths = (async () => {
@@ -26,6 +66,10 @@ interface Props {
 
 const { post } = Astro.props as Props;
 const { Content } = await post.render();
+
+const body = post.body ?? "";
+const musicUrls = extractMusicUrls(body);
+const musicLinks = musicUrls.length > 0 ? await fetchMusicLinksForUrls(musicUrls, post.slug) : {};
 ---
 
 <NotePost 


### PR DESCRIPTION
…usic links in built HTML. Update NotePost layout to extract and fetch music links from Spotify and Apple Music URLs during build time, improving error handling and logging. Refactor Vite plugin to preserve blank lines in note content and adjust styles for better layout.