### PR TITLE
Fix notes blank line rendering to match reference site behavior

### DIFF
--- a/src/layouts/NotePost.astro
+++ b/src/layouts/NotePost.astro
@@ -743,14 +743,17 @@ window.__NOTE_SLUG__ = ${JSON.stringify(slug)};
   }
 
   .post-content {
-    line-height: 1.7;
+    line-height: 1.9;
     font-size: 1rem;
     color: var(--fg);
   }
 
   .post-content :global(p) {
-    margin: 0 0 1em;
-    white-space: pre-wrap;
+    margin-bottom: 1em;
+  }
+
+  .post-content :global(p:last-child) {
+    margin-bottom: 0;
   }
 
   .post-content :global(h1),


### PR DESCRIPTION
Remove white-space: pre-wrap from post-content paragraphs, increase line-height to 1.9, and add p:last-child margin reset.