### PR TITLE
Fix: flush hero image to top of note card

### DIFF
--- a/src/layouts/NotePost.astro
+++ b/src/layouts/NotePost.astro
@@ -647,8 +647,8 @@ window.__NOTE_SLUG__ = ${JSON.stringify(slug)};
   }
 
   .post-hero {
-    margin: 0 -1rem 1.5rem;
-    border-radius: 12px 12px 0 0;
+    margin: -0.5rem -1rem 1.5rem;
+    border-radius: 16px 16px 0 0;
     overflow: hidden;
     line-height: 0;
   }
@@ -1013,6 +1013,10 @@ window.__NOTE_SLUG__ = ${JSON.stringify(slug)};
   @media (max-width: 768px) {
     .note-post {
       padding: 1.5rem 1rem;
+    }
+
+    .post-hero {
+      margin-top: -1.5rem;
     }
 
     .post-title {


### PR DESCRIPTION
Negative top margin cancels the card's padding so the image sits tight against the rounded top edge. Border-radius matches the card (16px) so corners clip correctly. Mobile breakpoint adjusted to match its larger padding (1.5rem).